### PR TITLE
Fixed issue with validation button not enabling

### DIFF
--- a/beers/templates/beers/validate.html
+++ b/beers/templates/beers/validate.html
@@ -256,7 +256,7 @@
           </select>
         </td>
         <td>
-          <button id="id_{{ uv.id }}_vbutton" class="validation-button validation-click" {% if not uv.possible %}disabled{% endif %}>
+          <button id="id_{{ uv.id }}_vbutton" class="validation-button validation-click" {% if not uv.possible_beer and not uv.possible_brewery %}disabled{% endif %}>
             Validate
           </button>
         </td>


### PR DESCRIPTION
The validation button wasn't enabling because the logic around checking if the button should be enabled had changed after the breweries were added.